### PR TITLE
  バックエンド関連

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ Thumbs.db
 /database/*.sqlite
 /database/*.sqlite3
 
+# Uploads (user uploaded files)
+/backend/uploads/*
+!/backend/uploads/.gitkeep
+
 # Logs
 *.log
 logs/

--- a/backend/handlers/profile.go
+++ b/backend/handlers/profile.go
@@ -87,7 +87,7 @@ func (app *App) CreateProfile(c *gin.Context) {
 		}
 
 		// 公開URL設定
-		iconURL = fmt.Sprintf("/api/profiles/%d/icon", req.UserID)
+		iconURL = fmt.Sprintf("http://localhost:8080/api/profiles/%d/icon", req.UserID)
 	}
 
 	// 誕生日の処理
@@ -324,7 +324,7 @@ func (app *App) UpdateProfile(c *gin.Context) {
 
 	// アイコンURLを設定
 	if newIconPath != "" || (currentIconPath.Valid && currentIconPath.String != "") {
-		profile.IconURL = fmt.Sprintf("/api/profiles/%d/icon", profile.ID)
+		profile.IconURL = fmt.Sprintf("http://localhost:8080/api/profiles/%d/icon", profile.ID)
 	}
 
 	c.JSON(http.StatusOK, profile)
@@ -365,7 +365,8 @@ func (app *App) GetProfile(c *gin.Context) {
 
 	// アイコンURLの設定
 	if iconPath.Valid && iconPath.String != "" {
-		profile.IconURL = fmt.Sprintf("/api/profiles/%d/icon", profile.ID)
+		// 完全なURLを返す（バックエンドのポート8080を指定）
+		profile.IconURL = fmt.Sprintf("http://localhost:8080/api/profiles/%d/icon", profile.ID)
 	}
 
 	c.JSON(http.StatusOK, profile)
@@ -498,7 +499,7 @@ func (app *App) GetProfilesByUserID(c *gin.Context) {
 		// アイコンURLの設定
 		if iconPath.Valid && iconPath.String != "" {
 			profile.IconPath = iconPath.String
-			profile.IconURL = fmt.Sprintf("/api/profiles/%d/icon", profile.ID)
+			profile.IconURL = fmt.Sprintf("http://localhost:8080/api/profiles/%d/icon", profile.ID)
 		}
 
 		profiles = append(profiles, profile)

--- a/backend/models/link.go
+++ b/backend/models/link.go
@@ -6,6 +6,7 @@ import "time"
 type Link struct {
 	ID          int       `json:"id" db:"id"`
 	UsersID     int       `json:"user_id" db:"user_id"`
+	ProfileID   *int      `json:"profile_id,omitempty" db:"profile_id"`
 	ImageURL    *string   `json:"image_url,omitempty" db:"image_url"`
 	Title       string    `json:"title" db:"title"`
 	Description *string   `json:"description,omitempty" db:"description"`
@@ -16,7 +17,8 @@ type Link struct {
 
 // リンク作成用リクエスト
 type CreateLinkRequest struct {
-	UsersID     int     `json:"user_id" binding:"required"`
+	UsersID     *int    `json:"user_id,omitempty"`
+	ProfileID   *int    `json:"profile_id,omitempty"`
 	ImageURL    *string `json:"image_url,omitempty"`
 	Title       string  `json:"title" binding:"required,max=100"`
 	Description *string `json:"description,omitempty"`

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -30,27 +30,32 @@ func SetupRoutes(r *gin.Engine) {
 		links := api.Group("/links")
 		links.Use(middleware.AuthRequired())
 		{
-			links.POST("", app.CreateLink)                     // 新規リンク作成
-			links.GET("/user/:user_id", app.GetLinksByUser)    // ユーザー別リンク一覧
-			links.GET("/:id", app.GetLink)                     // リンク詳細取得
-			links.PUT("/:id", app.UpdateLink)                  // リンク更新
-			links.DELETE("/:id", app.DeleteLink)               // リンク削除
+			links.POST("", app.CreateLink)                         // 新規リンク作成
+			links.GET("/user/:user_id", app.GetLinksByUser)        // ユーザー別リンク一覧
+			links.GET("/:id", app.GetLink)                         // リンク詳細取得
+			links.PUT("/:id", app.UpdateLink)                      // リンク更新
+			links.DELETE("/:id", app.DeleteLink)                   // リンク削除
 
-			links.GET("/types/common", app.GetCommonLinkTypes) // 共通リンクテンプレ取得
+			links.GET("/types/common", app.GetCommonLinkTypes)     // 共通リンクテンプレ取得
 		}
+
+		// 公開リンクAPI（認証不要）
+		api.GET("/links/profile/:profile_id", app.GetLinksByProfile) // プロフィール別リンク一覧（公開）
 
 		// プロフィール関連
 		profiles := api.Group("/profiles")
 		profiles.Use(middleware.AuthRequired())
 		{
 			profiles.POST("", app.CreateProfile)          // プロフィール作成
-			profiles.GET("/:id", app.GetProfile)          // プロフィール取得
 			profiles.PUT("/:id", app.UpdateProfile)       // プロフィール更新
-			profiles.GET("/:id/icon", app.GetProfileIcon) // プロフィールアイコン取得
 
 			// プロフィールごとのオプションプロフィール一覧取得
 			profiles.GET("/:id/option-profiles", app.GetOptionProfilesByProfileID)
 		}
+
+		// 公開API（認証不要）
+		api.GET("/profiles/:id", app.GetProfile)         // プロフィール取得（公開）
+		api.GET("/profiles/:id/icon", app.GetProfileIcon) // プロフィールアイコン取得（公開）
 
 		// option_profiles関連
 		optionProfiles := api.Group("/option_profiles")

--- a/backend/uploads/.gitkeep
+++ b/backend/uploads/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the uploads directory is tracked by Git
+# The actual uploaded files are ignored by .gitignore

--- a/frontend/src/app/profile/[id]/page.module.css
+++ b/frontend/src/app/profile/[id]/page.module.css
@@ -1,7 +1,7 @@
 /* ==== レイアウト ==== */
 .container {
   min-height: 100vh;
-  background-image: url('/backpicPC.png');
+  background-image: url("/backpicPC.png");
   background-size: cover;
   background-position: center;
   display: flex;
@@ -11,7 +11,7 @@
 }
 @media (max-width: 768px) {
   .container {
-    background-image: url('/backpicMobile.png');
+    background-image: url("/backpicMobile.png");
   }
 }
 
@@ -26,16 +26,38 @@
 }
 
 /* ==== 見出し ==== */
+.profileHeader {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.iconContainer {
+  flex-shrink: 0;
+}
+
+.profileIcon {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #77a0ed;
+}
+
+.headerText {
+  flex: 1;
+}
+
 .title {
-  text-align: center;
   color: #77a0ed;
   margin-bottom: 6px;
   font-size: 2rem;
+  margin: 0;
 }
 .subtitle {
-  text-align: center;
   color: #77a0ed;
-  margin-bottom: 24px;
+  margin: 6px 0 0 0;
   font-size: 1.1rem;
 }
 
@@ -74,7 +96,7 @@
 
 .backLink:hover {
   text-decoration: none;
-  opacity: 0.8; 
+  opacity: 0.8;
 }
 
 .backButton {
@@ -97,4 +119,124 @@
   color: #77a0ed;
   text-align: center;
   margin-bottom: 20px;
+}
+
+/* ==== リンクセクション ==== */
+.linksSection {
+  margin: 30px 0;
+}
+
+.sectionTitle {
+  color: #77a0ed;
+  font-size: 1.5rem;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.linksGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 16px;
+}
+
+.linkCard {
+  background-color: rgba(255, 255, 255, 0.6);
+  border: 2px solid #77a0ed;
+  border-radius: 12px;
+  padding: 16px;
+  text-decoration: none;
+  transition: all 0.3s ease;
+  display: block;
+}
+
+.linkCard:hover {
+  background-color: rgba(119, 160, 237, 0.1);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(119, 160, 237, 0.3);
+}
+
+.linkContent {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.linkIconContainer {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+}
+
+.linkIcon {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1px solid #77a0ed;
+}
+
+.linkInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.linkTitle {
+  color: #77a0ed;
+  font-size: 1.3rem;
+  font-weight: bold;
+  margin: 0;
+  word-wrap: break-word;
+  line-height: 1.3;
+}
+
+.linkDescription {
+  color: #0056b3;
+  font-size: 0.95rem;
+  margin: 0;
+  line-height: 1.4;
+  word-wrap: break-word;
+}
+
+.linkUrl {
+  color: #666;
+  font-size: 0.8rem;
+  margin: 0;
+  word-break: break-all;
+  opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+  .linksGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .profileHeader {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .linkContent {
+    gap: 12px;
+  }
+
+  .linkIconContainer {
+    width: 40px;
+    height: 40px;
+  }
+
+  .linkIcon {
+    width: 40px;
+    height: 40px;
+  }
+
+  .linkTitle {
+    font-size: 1.1rem;
+  }
+
+  .linkDescription {
+    font-size: 0.9rem;
+  }
 }

--- a/frontend/src/app/profile/new/page.module.css
+++ b/frontend/src/app/profile/new/page.module.css
@@ -1,6 +1,6 @@
 .container {
   min-height: 100vh;
-  background-image: url('/backpicPC.png');
+  background-image: url("/backpicPC.png");
   background-size: cover;
   background-position: center;
   background-attachment: fixed;
@@ -13,7 +13,7 @@
 
 @media (max-width: 768px) {
   .container {
-    background-image: url('/bsackpicMobile.png');
+    background-image: url("/bsackpicMobile.png");
   }
 }
 
@@ -108,7 +108,7 @@
 
 .backLink:hover {
   text-decoration: none;
-  opacity: 0.8; 
+  opacity: 0.8;
 }
 
 .snsSection {
@@ -119,8 +119,23 @@
 
 .optionalField {
   display: flex;
+  flex-direction: column;
   gap: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
+  padding: 15px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.optionalField input,
+.optionalField textarea {
+  margin-bottom: 5px;
+}
+
+.optionalField label {
+  font-size: 0.9rem;
+  margin-top: 5px;
 }
 
 .addOptionalButton {

--- a/frontend/src/app/profile/new/page.tsx
+++ b/frontend/src/app/profile/new/page.tsx
@@ -1,11 +1,17 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import styles from './page.module.css';
-import Link from 'next/link';
+import { useState } from "react";
+import styles from "./page.module.css";
+import Link from "next/link";
+import { getUser, getToken, authenticatedFetch } from "@/utils/auth";
 
 type OptionalField = { label: string; value: string };
-type OtherLink = { label: string; url: string };
+type OtherLink = {
+  label: string;
+  url: string;
+  description: string;
+  iconFile?: File;
+};
 
 interface FormData {
   profileTitle: string;
@@ -27,21 +33,21 @@ interface FormData {
 
 export default function NewProfilePage() {
   const [formData, setFormData] = useState<FormData>({
-    profileTitle: '',
-    profileDescription: '',
-    name: '',
-    title: '',
-    bio: '',
-    birthday: '',
-    birthplace: '',
-    hobby: '',
+    profileTitle: "",
+    profileDescription: "",
+    name: "",
+    title: "",
+    bio: "",
+    birthday: "",
+    birthplace: "",
+    hobby: "",
     sns: {
-      twitter: '',
-      instagram: '',
-      github: '',
+      twitter: "",
+      instagram: "",
+      github: "",
     },
-    optionalFields: [{ label: '', value: '' }],
-    otherLinks: [{ label: '', url: '' }],
+    optionalFields: [{ label: "", value: "" }],
+    otherLinks: [{ label: "", url: "", description: "" }],
   });
 
   const [iconFile, setIconFile] = useState<File | null>(null);
@@ -49,16 +55,24 @@ export default function NewProfilePage() {
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     index?: number,
-    fieldType?: 'label' | 'value' | 'url',
-    targetList?: 'optionalFields' | 'otherLinks'
+    fieldType?: "label" | "value" | "url" | "description",
+    targetList?: "optionalFields" | "otherLinks"
   ) => {
     const { name, value } = e.target;
 
     if (index !== undefined && fieldType && targetList) {
       const updated = [...formData[targetList]];
-      if (targetList === 'optionalFields' && (fieldType === 'label' || fieldType === 'value')) {
+      if (
+        targetList === "optionalFields" &&
+        (fieldType === "label" || fieldType === "value")
+      ) {
         (updated as OptionalField[])[index][fieldType] = value;
-      } else if (targetList === 'otherLinks' && (fieldType === 'label' || fieldType === 'url')) {
+      } else if (
+        targetList === "otherLinks" &&
+        (fieldType === "label" ||
+          fieldType === "url" ||
+          fieldType === "description")
+      ) {
         (updated as OtherLink[])[index][fieldType] = value;
       }
       setFormData({ ...formData, [targetList]: updated });
@@ -84,49 +98,241 @@ export default function NewProfilePage() {
   const addOptionalField = () => {
     setFormData({
       ...formData,
-      optionalFields: [...formData.optionalFields, { label: '', value: '' }],
+      optionalFields: [...formData.optionalFields, { label: "", value: "" }],
     });
   };
 
   const addOtherLink = () => {
     setFormData({
       ...formData,
-      otherLinks: [...formData.otherLinks, { label: '', url: '' }],
+      otherLinks: [
+        ...formData.otherLinks,
+        { label: "", url: "", description: "" },
+      ],
     });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleOtherLinkIconChange = (index: number, file: File | null) => {
+    const updated = [...formData.otherLinks];
+    updated[index].iconFile = file || undefined;
+    setFormData({ ...formData, otherLinks: updated });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!formData.profileTitle.trim()) {
-      alert('プロフィールタイトルは必須です。');
+      alert("プロフィールタイトルは必須です。");
       return;
     }
 
     if (!formData.name.trim()) {
-      alert('名前は必須です。');
+      alert("名前は必須です。");
       return;
     }
 
-    console.log('送信内容:', formData);
-    console.log('アイコン画像:', iconFile);
-    alert('プロフィールを登録しました（仮）');
+    try {
+      // ユーザー情報とトークンを取得
+      const user = getUser();
+      const token = getToken();
+
+      if (!user || !token) {
+        alert("ログインが必要です。");
+        return;
+      }
+
+      // アイコン画像をbase64に変換
+      let iconBase64 = "";
+      if (iconFile) {
+        iconBase64 = await fileToBase64(iconFile);
+      }
+
+      // APIリクエスト用のデータ構造に変換
+      const profileData = {
+        user_id: user.id,
+        display_name: formData.name,
+        icon_base64: iconBase64,
+        aka: formData.title,
+        hometown: formData.birthplace,
+        birthdate: formData.birthday,
+        hobby: formData.hobby,
+        comment: formData.bio,
+        title: formData.profileTitle,
+        description: formData.profileDescription,
+      };
+
+      // 基本プロフィールを作成
+      const response = await authenticatedFetch("/api/profiles", {
+        method: "POST",
+        body: JSON.stringify(profileData),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        alert(
+          `プロフィールの登録に失敗しました: ${
+            error.error || "エラーが発生しました"
+          }`
+        );
+        return;
+      }
+
+      const createdProfile = await response.json();
+      console.log("作成されたプロフィール:", createdProfile);
+
+      // オプション項目を保存
+      await saveOptionalFields(createdProfile.id);
+
+      // SNSリンクと任意のリンクを保存
+      await saveLinks(createdProfile.id);
+
+      alert("プロフィールを登録しました！");
+      // プロフィール詳細ページまたはマイページに遷移
+      window.location.href = "/mypage";
+    } catch (error) {
+      console.error("プロフィール登録エラー:", error);
+      alert("プロフィールの登録中にエラーが発生しました。");
+    }
+  };
+
+  // オプション項目を保存
+  const saveOptionalFields = async (profileId: number) => {
+    for (const field of formData.optionalFields) {
+      if (field.label.trim() && field.value.trim()) {
+        try {
+          const optionData = {
+            title: field.label,
+            content: field.value,
+            profile_id: profileId,
+          };
+
+          await authenticatedFetch("/api/option_profiles", {
+            method: "POST",
+            body: JSON.stringify(optionData),
+          });
+        } catch (error) {
+          console.error("オプション項目の保存エラー:", error);
+        }
+      }
+    }
+  };
+
+  // SNSリンクと任意のリンクを保存
+  const saveLinks = async (profileId: number) => {
+    // バックエンドからプリセットアイコン情報を取得
+    let presetIcons: Record<string, string> = {};
+    try {
+      const response = await authenticatedFetch("/api/links/types/common");
+      if (response.ok) {
+        const commonTypes = await response.json();
+        presetIcons = commonTypes.reduce(
+          (acc: Record<string, string>, type: any) => {
+            // "Twitter/X" -> "Twitter", "GitHub" -> "GitHub" などのマッピング
+            const key = type.name.includes("/")
+              ? type.name.split("/")[0]
+              : type.name;
+            acc[key] = type.icon_url;
+            return acc;
+          },
+          {}
+        );
+      }
+    } catch (error) {
+      console.error("プリセットアイコン情報の取得エラー:", error);
+      // フォールバック用のアイコンマッピング
+      presetIcons = {
+        Twitter: "https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/x.svg",
+        Instagram:
+          "https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/instagram.svg",
+        GitHub: "https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/github.svg",
+      };
+    }
+
+    // SNSリンクを保存
+    const snsLinks = [
+      { title: "Twitter", url: formData.sns.twitter },
+      { title: "Instagram", url: formData.sns.instagram },
+      { title: "GitHub", url: formData.sns.github },
+    ];
+
+    for (const link of snsLinks) {
+      if (link.url.trim()) {
+        try {
+          const snsLinkData = {
+            profile_id: profileId,
+            title: link.title,
+            url: link.url,
+            image_url: presetIcons[link.title],
+          };
+
+          await authenticatedFetch("/api/links", {
+            method: "POST",
+            body: JSON.stringify(snsLinkData),
+          });
+        } catch (error) {
+          console.error("SNSリンクの保存エラー:", error);
+        }
+      }
+    }
+
+    // 任意のリンクを保存
+    for (const link of formData.otherLinks) {
+      if (link.label.trim() && link.url.trim()) {
+        try {
+          // アイコン画像をbase64に変換（存在する場合）
+          let imageUrl = null;
+          if (link.iconFile) {
+            const iconBase64 = await fileToBase64(link.iconFile);
+            imageUrl = `data:${link.iconFile.type};base64,${iconBase64}`;
+          }
+
+          const linkData = {
+            profile_id: profileId,
+            title: link.label,
+            url: link.url,
+            description: link.description || null,
+            image_url: imageUrl,
+          };
+
+          await authenticatedFetch("/api/links", {
+            method: "POST",
+            body: JSON.stringify(linkData),
+          });
+        } catch (error) {
+          console.error("任意リンクの保存エラー:", error);
+        }
+      }
+    }
+  };
+
+  // ファイルをbase64に変換するヘルパー関数
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        const result = reader.result as string;
+        // data:image/png;base64, の部分を除去してbase64のみを取得
+        const base64 = result.split(",")[1];
+        resolve(base64);
+      };
+      reader.onerror = (error) => reject(error);
+    });
   };
 
   return (
     <div className={styles.container}>
-      <Link href="/mypage" className={styles.backLink}>
+      <Link href='/mypage' className={styles.backLink}>
         &lt; MyProfile Page
       </Link>
       <div className={styles.overlay}>
         <h1 className={styles.title}>プロフィール新規作成</h1>
         <form onSubmit={handleSubmit} className={styles.form}>
-
           <label>
             プロフィールタイトル*：
             <input
-              type="text"
-              name="profileTitle"
+              type='text'
+              name='profileTitle'
               required
               value={formData.profileTitle}
               onChange={handleChange}
@@ -136,7 +342,7 @@ export default function NewProfilePage() {
           <label>
             概要：
             <textarea
-              name="profileDescription"
+              name='profileDescription'
               value={formData.profileDescription}
               onChange={handleChange}
             />
@@ -144,18 +350,14 @@ export default function NewProfilePage() {
 
           <label>
             アイコン画像をアップロード：
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleFileChange}
-            />
+            <input type='file' accept='image/*' onChange={handleFileChange} />
           </label>
 
           <label>
             名前*：
             <input
-              type="text"
-              name="name"
+              type='text'
+              name='name'
               required
               value={formData.name}
               onChange={handleChange}
@@ -165,8 +367,8 @@ export default function NewProfilePage() {
           <label>
             肩書き：
             <input
-              type="text"
-              name="title"
+              type='text'
+              name='title'
               value={formData.title}
               onChange={handleChange}
             />
@@ -174,18 +376,14 @@ export default function NewProfilePage() {
 
           <label>
             一言Bio：
-            <textarea
-              name="bio"
-              value={formData.bio}
-              onChange={handleChange}
-            />
+            <textarea name='bio' value={formData.bio} onChange={handleChange} />
           </label>
 
           <label>
             誕生日：
             <input
-              type="date"
-              name="birthday"
+              type='date'
+              name='birthday'
               value={formData.birthday}
               onChange={handleChange}
             />
@@ -194,8 +392,8 @@ export default function NewProfilePage() {
           <label>
             出身地：
             <input
-              type="text"
-              name="birthplace"
+              type='text'
+              name='birthplace'
               value={formData.birthplace}
               onChange={handleChange}
             />
@@ -204,8 +402,8 @@ export default function NewProfilePage() {
           <label>
             趣味：
             <input
-              type="text"
-              name="hobby"
+              type='text'
+              name='hobby'
               value={formData.hobby}
               onChange={handleChange}
             />
@@ -215,22 +413,26 @@ export default function NewProfilePage() {
           {formData.optionalFields.map((field, index) => (
             <div key={index} className={styles.optionalField}>
               <input
-                type="text"
-                placeholder="項目名"
+                type='text'
+                placeholder='項目名'
                 value={field.label}
-                onChange={(e) => handleChange(e, index, 'label', 'optionalFields')}
+                onChange={(e) =>
+                  handleChange(e, index, "label", "optionalFields")
+                }
               />
               <input
-                type="text"
-                placeholder="内容"
+                type='text'
+                placeholder='内容'
                 value={field.value}
-                onChange={(e) => handleChange(e, index, 'value', 'optionalFields')}
+                onChange={(e) =>
+                  handleChange(e, index, "value", "optionalFields")
+                }
               />
             </div>
           ))}
 
           <button
-            type="button"
+            type='button'
             onClick={addOptionalField}
             className={styles.addOptionalButton}
           >
@@ -243,8 +445,8 @@ export default function NewProfilePage() {
             <label>
               Twitter:
               <input
-                type="url"
-                name="twitter"
+                type='url'
+                name='twitter'
                 value={formData.sns.twitter}
                 onChange={handleChange}
               />
@@ -253,8 +455,8 @@ export default function NewProfilePage() {
             <label>
               Instagram:
               <input
-                type="url"
-                name="instagram"
+                type='url'
+                name='instagram'
                 value={formData.sns.instagram}
                 onChange={handleChange}
               />
@@ -263,41 +465,61 @@ export default function NewProfilePage() {
             <label>
               GitHub:
               <input
-                type="url"
-                name="github"
+                type='url'
+                name='github'
                 value={formData.sns.github}
                 onChange={handleChange}
               />
             </label>
           </fieldset>
 
-          <h3>任意のリンク</h3>
+          <h3>任意のリンクです</h3>
           {formData.otherLinks.map((link, index) => (
             <div key={index} className={styles.optionalField}>
               <input
-                type="text"
-                placeholder="リンク名"
+                type='text'
+                placeholder='リンク名'
                 value={link.label}
-                onChange={(e) => handleChange(e, index, 'label', 'otherLinks')}
+                onChange={(e) => handleChange(e, index, "label", "otherLinks")}
               />
               <input
-                type="url"
-                placeholder="URL"
+                type='url'
+                placeholder='URL'
                 value={link.url}
-                onChange={(e) => handleChange(e, index, 'url', 'otherLinks')}
+                onChange={(e) => handleChange(e, index, "url", "otherLinks")}
               />
+              <textarea
+                placeholder='リンクの説明（任意）'
+                value={link.description}
+                onChange={(e) =>
+                  handleChange(e, index, "description", "otherLinks")
+                }
+              />
+              <label>
+                アイコン画像（任意）:
+                <input
+                  type='file'
+                  accept='image/*'
+                  onChange={(e) =>
+                    handleOtherLinkIconChange(
+                      index,
+                      e.target.files?.[0] || null
+                    )
+                  }
+                />
+              </label>
             </div>
           ))}
 
           <button
-            type="button"
+            type='button'
             onClick={addOtherLink}
             className={styles.addOptionalButton}
           >
             任意リンクを追加 +
           </button>
 
-          <button type="submit" className={styles.submitButton}>
+          <button type='submit' className={styles.submitButton}>
             登録する
           </button>
         </form>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,36 @@
+{
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/next",
+      "config": {
+        "buildCommand": "cd frontend && npm run build"
+      }
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "https://qrsona.onrender.com/api/$1"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET, POST, PUT, DELETE, OPTIONS"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type, Authorization"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  - リンク機能を拡張し、profile_idをサポート
  - リンクモデルにProfileIDフィールドを追加
  - プロフィール別リンク一覧取得API (/api/links/profile/:profile_id) を実装
  - プロフィール関連の公開API化（認証不要）
  - アイコンURL生成を相対パスから絶対パスに変更
  - .gitignoreにアップロード用ディレクトリを追加

  フロントエンド関連

  - プロフィール詳細ページにアイコン表示機能を追加
  - プロフィール詳細ページにリンクセクションを追加
  - プロフィール新規作成ページの機能拡張
  - オプション項目とリンクの保存機能を実装
  - スタイルを調整し、レスポンシブデザインに対応

  新機能

  - プロフィール別リンクの表示機能
  - プロフィール新規作成時の完全な実装
  - アイコン画像のアップロード機能
  - SNSリンクの保存機能